### PR TITLE
Pomodoro timer pinning

### DIFF
--- a/macos/Pomodoro/Sources/Bridge.swift
+++ b/macos/Pomodoro/Sources/Bridge.swift
@@ -99,8 +99,21 @@ class Bridge: NSObject, WKScriptMessageHandler {
             
         case "hideWindow":
             windowController?.hide()
+        case "forceHideWindow":
+            windowController?.forceHide()
         case "quitApp":
             NSApplication.shared.terminate(nil)
+            
+        // --- Pin Window Actions ---
+        case "setPinned":
+            if let pinned = body["pinned"] as? Bool {
+                windowController?.setPinned(pinned)
+            }
+        case "togglePinned":
+            windowController?.togglePinned()
+        case "getPinnedState":
+            let isPinned = windowController?.isPinned ?? false
+            sendToJS(action: "pinnedStateChanged", data: ["isPinned": isPinned])
         case "playClickSound":
             print("Bridge: Playing click sound...")
             if let soundUrl = Bundle.main.url(forResource: "click", withExtension: "mp3") {

--- a/macos/Pomodoro/Sources/StatusBarController.swift
+++ b/macos/Pomodoro/Sources/StatusBarController.swift
@@ -43,6 +43,18 @@ class StatusBarController {
         menu.addItem(NSMenuItem(title: "Skip", action: #selector(menuSkip), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Reset", action: #selector(menuReset), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
+        
+        // Pin/Unpin option
+        let isPinned = windowController.isPinned
+        let pinItem = NSMenuItem(
+            title: isPinned ? "Unpin from Screen" : "Pin to Screen",
+            action: #selector(menuTogglePin),
+            keyEquivalent: "p"
+        )
+        pinItem.keyEquivalentModifierMask = [.command, .shift]
+        menu.addItem(pinItem)
+        
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "About Pomodoro", action: #selector(menuAbout), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Check for Updates...", action: #selector(menuUpdate), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
@@ -67,6 +79,10 @@ class StatusBarController {
 
     @objc func menuReset() {
         windowController.bridge.sendToJS(action: "menuAction", data: ["type": "reset"])
+    }
+    
+    @objc func menuTogglePin() {
+        windowController.togglePinned()
     }
 
     @objc func menuAbout() {

--- a/src/services/nativeBridge.ts
+++ b/src/services/nativeBridge.ts
@@ -103,10 +103,39 @@ export const NativeBridge = {
   },
 
   /**
+   * Force hides the native popup window (even if pinned).
+   */
+  forceHideWindow() {
+    this.postMessage('forceHideWindow');
+  },
+
+  /**
    * Terminates the native application.
    */
   quitApp() {
     this.postMessage('quitApp');
+  },
+
+  /**
+   * Sets the window pinned state.
+   * When pinned, the window stays visible even when clicking outside.
+   */
+  setPinned(pinned: boolean) {
+    this.postMessage('setPinned', { pinned });
+  },
+
+  /**
+   * Toggles the window pinned state.
+   */
+  togglePinned() {
+    this.postMessage('togglePinned');
+  },
+
+  /**
+   * Requests the current pinned state from native.
+   */
+  getPinnedState() {
+    this.postMessage('getPinnedState');
   },
 
   /**


### PR DESCRIPTION
Add a "pin to screen" feature to keep the Pomodoro timer window visible while focusing on other applications.

This feature allows users to keep the timer on screen, floating above other apps, instead of automatically hiding when the app loses focus, which is the default behavior for menu bar apps.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d662c7e-3a8b-49b7-8da9-e7a0eafb795c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d662c7e-3a8b-49b7-8da9-e7a0eafb795c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

