### PR TITLE
Break distinction UX

### DIFF
--- a/src/state/pomodoroStore.ts
+++ b/src/state/pomodoroStore.ts
@@ -303,7 +303,7 @@ export const usePomodoroStore = create<PomodoroStore>((set, get) => ({
     NativeBridge.endTimerActivity();
 
     // Trigger engaging notification
-    const title = currentType === 'focus' ? "Focus Session Complete" : "Break Over";
+    const title = currentType === 'focus' ? "Focus Session Complete" : currentType === 'shortBreak' ? "Short Break Over" : "Long Break Over";
     const body = getRandomMessage(currentType as keyof typeof MESSAGES);
     NativeBridge.showNotification(title, body);
     

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -521,16 +521,23 @@ const App: React.FC = () => {
         </div>
       </main>
 
-      <div style={{ 
-        display: 'flex', 
-        justifyContent: 'center',
-        gap: '6px', 
-        opacity: 0.3,
-        paddingBottom: '16px', 
-        flexShrink: 0,
-        zIndex: 1,
-        pointerEvents: 'none'
-      }}>
+      <div 
+        style={{ 
+          display: 'flex', 
+          justifyContent: 'center',
+          gap: '6px', 
+          opacity: 0.3,
+          paddingBottom: '16px', 
+          flexShrink: 0,
+          zIndex: 1,
+          cursor: 'default',
+        }}
+        title={
+          sessionType === 'longBreak'
+            ? `Long break – ${config.sessionsUntilLongBreak} focus sessions until next long break`
+            : `${focusInCycleCount} of ${config.sessionsUntilLongBreak} focus sessions completed before long break`
+        }
+      >
         {Array.from({ length: config.sessionsUntilLongBreak }).map((_, i) => (
           <div 
             key={i}

--- a/src/ui/TimerView.tsx
+++ b/src/ui/TimerView.tsx
@@ -67,14 +67,18 @@ const TimerView: React.FC = () => {
           <circle cx="12" cy="12" r="2" fill="currentColor" fillOpacity="0.2" />
         </svg>
       );
-      case 'shortBreak':
-      case 'longBreak': return (
+      case 'shortBreak': return (
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
           <path d="M18 8h1a4 4 0 0 1 0 8h-1" />
           <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z" />
           <line x1="6" y1="1" x2="6" y2="4" />
           <line x1="10" y1="1" x2="10" y2="4" />
           <line x1="14" y1="1" x2="14" y2="4" />
+        </svg>
+      );
+      case 'longBreak': return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
         </svg>
       );
     }
@@ -135,7 +139,7 @@ const TimerView: React.FC = () => {
           textTransform: 'uppercase',
           opacity: 0.6
         }}>
-          {session.type === 'focus' ? 'FOCUS' : 'BREAK'}
+          {session.type === 'focus' ? 'FOCUS' : session.type === 'shortBreak' ? 'SHORT BREAK' : 'LONG BREAK'}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Enhance Pomodoro timer UX by clarifying break types with specific labels and icons, adding detailed cycle progress tooltips, and improving notification messages.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f9ea8749-a56f-4a12-87c1-b93743b2baaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9ea8749-a56f-4a12-87c1-b93743b2baaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

