### PR TITLE
feat(tasks): clear all completed tasks in one click

### DIFF
--- a/macos/Pomodoro/Sources/Bridge.swift
+++ b/macos/Pomodoro/Sources/Bridge.swift
@@ -71,6 +71,8 @@ class Bridge: NSObject, WKScriptMessageHandler {
             if let id = body["id"] as? String {
                 deleteTask(id: id)
             }
+        case "db_clearCompletedTasks":
+            clearCompletedTasks()
         case "db_updateTask":
             if let id = body["id"] as? String,
                let title = body["title"] as? String,
@@ -282,6 +284,16 @@ class Bridge: NSObject, WKScriptMessageHandler {
             }
         } catch {
             print("Bridge: db_deleteTask failed: \(error)")
+        }
+    }
+
+    private func clearCompletedTasks() {
+        do {
+            try DatabaseManager.shared.dbPool.write { db in
+                try db.execute(sql: "UPDATE tasks SET status = 2 WHERE status = 1")
+            }
+        } catch {
+            print("Bridge: db_clearCompletedTasks failed: \(error)")
         }
     }
     

--- a/src/services/nativeBridge.ts
+++ b/src/services/nativeBridge.ts
@@ -71,6 +71,10 @@ export const NativeBridge = {
     this.postMessage('db_deleteTask', { id });
   },
 
+  db_clearCompletedTasks() {
+    this.postMessage('db_clearCompletedTasks');
+  },
+
   db_updateTask(id: string, title: string, estimatedPomos: number, tag?: string, projectId?: string) {
     this.postMessage('db_updateTask', { id, title, estimatedPomos, tag, projectId });
   },

--- a/src/state/taskStore.ts
+++ b/src/state/taskStore.ts
@@ -28,6 +28,7 @@ interface TaskStore {
   addTask: (title: string, estimatedPomos: number, tag?: string) => string;
   toggleTask: (id: string) => void;
   deleteTask: (id: string) => void;
+  clearCompletedTasks: () => void;
   updateTask: (id: string, updates: { title: string; estimatedPomos: number; tag?: string }) => void;
   setActiveTask: (id: string | null) => void;
   incrementCompletedPomos: (id: string) => void;
@@ -122,6 +123,29 @@ export const useTaskStore = create<TaskStore>((set, get) => ({
       tasks: state.tasks.filter((t) => t.id !== id),
       activeTaskId: state.activeTaskId === id ? null : state.activeTaskId,
     }));
+  },
+
+  clearCompletedTasks: () => {
+    const { tasks } = get();
+    const hasCompleted = tasks.some((t) => t.status === 1);
+    if (!hasCompleted) return;
+
+    NativeBridge.db_clearCompletedTasks();
+
+    set((state) => {
+      const remainingTasks = state.tasks.filter((t) => t.status !== 1);
+      let nextActiveId = state.activeTaskId;
+
+      if (state.activeTaskId && !remainingTasks.some((t) => t.id === state.activeTaskId)) {
+        const nextTask = remainingTasks.find((t) => t.status === 0);
+        nextActiveId = nextTask ? nextTask.id : null;
+      }
+
+      return {
+        tasks: remainingTasks,
+        activeTaskId: nextActiveId,
+      };
+    });
   },
 
   updateTask: (id: string, updates: { title: string; estimatedPomos: number; tag?: string }) => {

--- a/src/test/taskStore.test.ts
+++ b/src/test/taskStore.test.ts
@@ -8,6 +8,7 @@ vi.mock('../services/nativeBridge', () => ({
     db_addTask: vi.fn(),
     db_updateTaskStatus: vi.fn(),
     db_deleteTask: vi.fn(),
+    db_clearCompletedTasks: vi.fn(),
     db_updateTask: vi.fn(),
     db_incrementPomos: vi.fn(),
     db_upsertProject: vi.fn(),
@@ -85,6 +86,52 @@ describe('TaskStore', () => {
     
     expect(useTaskStore.getState().tasks).toHaveLength(0);
     expect(NativeBridge.db_deleteTask).toHaveBeenCalledWith(taskId);
+  });
+
+  it('should clear all completed tasks and call native bridge', () => {
+    const { addTask, toggleTask, clearCompletedTasks } = useTaskStore.getState();
+
+    addTask('Active', 1);
+    addTask('Done 1', 1);
+    addTask('Done 2', 1);
+    const [activeId, done1Id, done2Id] = useTaskStore.getState().tasks.map((t) => t.id);
+
+    toggleTask(done1Id);
+    toggleTask(done2Id);
+
+    clearCompletedTasks();
+
+    const state = useTaskStore.getState();
+    expect(state.tasks).toHaveLength(1);
+    expect(state.tasks[0].id).toBe(activeId);
+    expect(state.tasks[0].status).toBe(0);
+    expect(state.activeTaskId).toBe(activeId);
+    expect(NativeBridge.db_clearCompletedTasks).toHaveBeenCalledTimes(1);
+  });
+
+  it('should auto-select next active task when clearing completed active task', () => {
+    const { addTask, toggleTask, clearCompletedTasks } = useTaskStore.getState();
+
+    addTask('Next', 1);
+    addTask('Done active', 1);
+    const [nextId, doneActiveId] = useTaskStore.getState().tasks.map((t) => t.id);
+
+    toggleTask(doneActiveId);
+    clearCompletedTasks();
+
+    const state = useTaskStore.getState();
+    expect(state.tasks).toHaveLength(1);
+    expect(state.activeTaskId).toBe(nextId);
+  });
+
+  it('should do nothing when clearing with no completed tasks', () => {
+    const { addTask, clearCompletedTasks } = useTaskStore.getState();
+
+    addTask('Active only', 1);
+    clearCompletedTasks();
+
+    expect(useTaskStore.getState().tasks).toHaveLength(1);
+    expect(NativeBridge.db_clearCompletedTasks).not.toHaveBeenCalled();
   });
 
   it('should auto-select next task on completion', () => {

--- a/src/ui/TaskShelf.tsx
+++ b/src/ui/TaskShelf.tsx
@@ -10,7 +10,8 @@ interface TaskShelfProps {
 }
 
 const TaskShelf: React.FC<TaskShelfProps> = ({ isOpen, onClose }) => {
-  const { tasks, activeTaskId, addTask, toggleTask, deleteTask, setActiveTask, updateTask } = useTaskStore();
+  const { tasks, activeTaskId, addTask, toggleTask, deleteTask, clearCompletedTasks, setActiveTask, updateTask } = useTaskStore();
+  const completedCount = tasks.filter((t) => t.isCompleted).length;
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [newTaskTag, setNewTaskTag] = useState(''); // Added tag state
   const [estimatedPomos, setEstimatedPomos] = useState(1);
@@ -73,6 +74,14 @@ const TaskShelf: React.FC<TaskShelfProps> = ({ isOpen, onClose }) => {
       e.stopPropagation();
     }
     onClose();
+  };
+
+  const handleClearCompleted = () => {
+    if (editingTaskId && tasks.find((t) => t.id === editingTaskId)?.isCompleted) {
+      setEditingTaskId(null);
+    }
+    NativeBridge.playClickSound();
+    clearCompletedTasks();
   };
 
   const shelfStyle: React.CSSProperties = {
@@ -312,6 +321,27 @@ const TaskShelf: React.FC<TaskShelfProps> = ({ isOpen, onClose }) => {
               </div>
             </div>
           </form>
+
+          {completedCount > 0 && (
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '12px', flexShrink: 0 }}>
+              <button
+                type="button"
+                onClick={handleClearCompleted}
+                aria-label={`Clear ${completedCount} completed ${completedCount === 1 ? 'task' : 'tasks'}`}
+                style={clearDoneButtonStyle}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.color = 'rgba(255, 255, 255, 0.85)';
+                  e.currentTarget.style.background = 'rgba(255, 255, 255, 0.08)';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.color = 'rgba(255, 255, 255, 0.4)';
+                  e.currentTarget.style.background = 'rgba(255, 255, 255, 0.04)';
+                }}
+              >
+                Clear done
+              </button>
+            </div>
+          )}
 
           {/* List Section - Scrollable */}
           <div 
@@ -820,6 +850,21 @@ const TaskItem: React.FC<TaskItemProps> = ({
       )}
     </div>
   );
+};
+
+const clearDoneButtonStyle: React.CSSProperties = {
+  background: 'rgba(255, 255, 255, 0.04)',
+  border: '1px solid rgba(255, 255, 255, 0.06)',
+  borderRadius: '8px',
+  height: '26px',
+  padding: '0 10px',
+  fontSize: '11px',
+  fontWeight: '600',
+  color: 'rgba(255, 255, 255, 0.4)',
+  cursor: 'pointer',
+  fontFamily: theme.fonts.brand,
+  letterSpacing: '-0.01em',
+  transition: 'all 0.2s cubic-bezier(0.16, 1, 0.3, 1)',
 };
 
 const stepperButtonStyle: React.CSSProperties = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Clear done** button to the tasks pane so completed items can be removed in one click instead of deleting them one by one.

## Changes

- **Task shelf UI**: Small ghost button below the task input, right-aligned, only visible when there are completed tasks. Matches existing glass/subtle button styling (11px label, soft border, hover brighten).
- **Task store**: New `clearCompletedTasks()` action removes all completed tasks from the list and reassigns the active task when needed.
- **Persistence**: Bulk soft-archive via `db_clearCompletedTasks` (same `status = 2` archive pattern as single delete).
- **Tests**: Coverage for bulk clear, active-task reassignment, and no-op when nothing is completed.

## Behavior

- Clicking **Clear done** archives every task with `status === 1` (completed), same as using the trash icon on each one individually.
- If the active task was completed, the next active incomplete task is selected automatically.
- Button is hidden when there are no completed tasks.

## Verification

- `npm test -- --run` — 60 tests passing
- `npm run build` — TypeScript + Vite build succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-872201b8-b97f-45df-b452-0a9314372bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-872201b8-b97f-45df-b452-0a9314372bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

