### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+Flumen is a macOS menu-bar focus timer. The frontend (React 19 + TypeScript + Vite) runs on any platform; the native Swift wrapper requires macOS with Xcode.
+
+### Quick reference
+
+| Action | Command |
+|--------|---------|
+| Install deps | `npm install` |
+| Dev server | `npm run dev` (serves at `localhost:5173`) |
+| Type check | `npx tsc --noEmit` |
+| Tests | `npx vitest --run` |
+| Build | `npm run build` |
+
+### Notes
+
+- The pre-commit hook runs `npx tsc --noEmit && npm test -- --run`. Both must pass before committing.
+- The Swift/native layer (`macos/Pomodoro/`) cannot build on Linux — only frontend dev is possible in Cloud Agent VMs.
+- The frontend communicates with the native layer via a `window.webkit.messageHandlers` bridge. In browser dev mode, `src/test/setup.ts` mocks this bridge, and the app gracefully degrades (no native persistence, no menu-bar features).
+- No Docker, databases, or external services are required for frontend development and testing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What's included

- Quick-reference table for common commands (dev server, type check, tests, build)
- Notes about pre-commit hooks, Swift/native layer limitations on Linux, and the WebKit bridge mock in dev mode
- Clarification that no Docker or external services are needed for frontend work

## Walkthrough

[flumen_timer_demo.mp4](https://cursor.com/agents/bc-52ca9223-d3d5-4719-9e05-f9184e16e347/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fflumen_timer_demo.mp4)

Timer app running in dev mode — started a session and added a task.

[Timer initial 25:00 state](https://cursor.com/agents/bc-52ca9223-d3d5-4719-9e05-f9184e16e347/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimer_initial_state.webp)
[Timer running with Test Task](https://cursor.com/agents/bc-52ca9223-d3d5-4719-9e05-f9184e16e347/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimer_running_with_task.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52ca9223-d3d5-4719-9e05-f9184e16e347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52ca9223-d3d5-4719-9e05-f9184e16e347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

