### PR TITLE
Format date in focus activity and show more data in the section

### DIFF
--- a/macos/Pomodoro/Sources/Bridge.swift
+++ b/macos/Pomodoro/Sources/Bridge.swift
@@ -371,7 +371,7 @@ class Bridge: NSObject, WKScriptMessageHandler {
                     SELECT DATE(timestamp, '+' || timezone_offset || ' minutes') as date, 
                            SUM(duration_seconds) / 3600.0 as hours
                     FROM session_logs
-                    WHERE timestamp >= DATETIME('now', '-7 days')
+                    WHERE timestamp >= DATETIME('now', '-60 days')
                     GROUP BY date
                     ORDER BY date ASC
                     """)

--- a/src/test/ReportsView.test.tsx
+++ b/src/test/ReportsView.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import ReportsView, { formatDuration } from '../ui/ReportsView';
+import ReportsView, {
+  formatDuration,
+  formatActivityDate,
+  buildFocusActivityChartData,
+} from '../ui/ReportsView';
 import { useStatsStore } from '../state/statsStore';
 import { NativeBridge } from '../services/nativeBridge';
 import React from 'react';
@@ -51,6 +55,43 @@ describe('ReportsView and Helpers', () => {
     vi.clearAllMocks();
   });
 
+  describe('formatActivityDate', () => {
+    it('should format dates for tooltip display', () => {
+      const formatted = formatActivityDate('2026-01-10', 'tooltip');
+      expect(formatted).toContain('2026');
+      expect(formatted).toMatch(/10/);
+    });
+
+    it('should format dates for axis display', () => {
+      const formatted = formatActivityDate('2026-01-10', 'axis');
+      expect(formatted).toMatch(/10/);
+    });
+  });
+
+  describe('buildFocusActivityChartData', () => {
+    it('should fill missing days with zero hours', () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const toKey = (d: Date) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      };
+
+      const data = buildFocusActivityChartData(
+        [{ date: toKey(today), hours: 2 }],
+        7
+      );
+
+      expect(data).toHaveLength(7);
+      expect(data[data.length - 1].hours).toBe(2);
+      expect(data[data.length - 2].hours).toBe(0);
+      expect(data.every((d) => d.dateLabel.length > 0)).toBe(true);
+    });
+  });
+
   describe('formatDuration', () => {
     it('should format seconds as minutes if under 1 hour', () => {
       expect(formatDuration(0)).toBe('0m');
@@ -99,6 +140,34 @@ describe('ReportsView and Helpers', () => {
     it('should call fetchReports on mount', () => {
       render(<ReportsView onClose={() => {}} />);
       expect(NativeBridge.db_getReports).toHaveBeenCalled();
+    });
+
+    it('should render focus activity range toggles', () => {
+      const { hydrateReports } = useStatsStore.getState();
+      const today = new Date();
+      const toKey = (d: Date) => {
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      };
+
+      hydrateReports({
+        dailyStats: [{ date: toKey(today), hours: 1.5 }],
+        projectDistribution: [],
+        totalFocusTime: 5400,
+        totalSessions: 1,
+        taskBreakdown: [],
+        streak: 1,
+      });
+
+      render(<ReportsView onClose={() => {}} />);
+
+      expect(screen.getByRole('button', { name: '7D' })).toBeDefined();
+      expect(screen.getByRole('button', { name: '30D' })).toBeDefined();
+      expect(screen.getByRole('button', { name: '60D' })).toBeDefined();
+
+      fireEvent.click(screen.getByRole('button', { name: '30D' }));
     });
 
     it('should show empty state when no reports or logs exist', () => {

--- a/src/ui/ReportsView.tsx
+++ b/src/ui/ReportsView.tsx
@@ -26,13 +26,65 @@ export const formatDuration = (seconds: number) => {
   return `${(seconds / 3600).toFixed(2)}h`;
 };
 
+export type FocusActivityRange = 7 | 30 | 60;
+
+const parseActivityDate = (dateStr: string) => new Date(`${dateStr}T12:00:00`);
+
+export const formatActivityDate = (
+  dateStr: string,
+  style: 'tooltip' | 'axis' | 'axisCompact' = 'tooltip'
+) => {
+  const date = parseActivityDate(dateStr);
+  if (style === 'axisCompact') {
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+  if (style === 'axis') {
+    return date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+  }
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+export const buildFocusActivityChartData = (
+  dailyStats: { date: string; hours: number }[],
+  rangeDays: FocusActivityRange
+) => {
+  const hoursByDate = new Map(dailyStats.map((d) => [d.date, d.hours]));
+  const end = new Date();
+  end.setHours(0, 0, 0, 0);
+
+  const start = new Date(end);
+  start.setDate(start.getDate() - (rangeDays - 1));
+
+  const result: { date: string; hours: number; dateLabel: string }[] = [];
+  const current = new Date(start);
+  while (current <= end) {
+    const year = current.getFullYear();
+    const month = String(current.getMonth() + 1).padStart(2, '0');
+    const day = String(current.getDate()).padStart(2, '0');
+    const dateKey = `${year}-${month}-${day}`;
+    result.push({
+      date: dateKey,
+      hours: hoursByDate.get(dateKey) ?? 0,
+      dateLabel: formatActivityDate(dateKey, rangeDays <= 7 ? 'axis' : 'axisCompact'),
+    });
+    current.setDate(current.getDate() + 1);
+  }
+  return result;
+};
+
 const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
   const fetchReports = useStatsStore(state => state.fetchReports);
   const stats = useStatsStore();
   const [exportStatus, setExportStatus] = useState<'idle' | 'exporting' | 'success'>('idle');
   const [isProjectExpanded, setIsProjectExpanded] = useState(false);
   const [projectFilter, setProjectFilter] = useState<'all' | 'tagged'>('all');
-  
+  const [activityRange, setActivityRange] = useState<FocusActivityRange>(7);
+
   useEffect(() => {
     fetchReports();
   }, [fetchReports]);
@@ -65,7 +117,12 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
     }, 60000);
   };
 
-  const dailyData = selectDailyFocusStats(stats);
+  const dailyStats = selectDailyFocusStats(stats);
+  const dailyData = React.useMemo(
+    () => buildFocusActivityChartData(dailyStats, activityRange),
+    [dailyStats, activityRange]
+  );
+  const activityBarSize = activityRange === 7 ? 20 : activityRange === 30 ? 8 : 4;
   const projectDataRaw = selectProjectDistribution(stats);
   
   const taskData = selectTaskBreakdown(stats);
@@ -251,30 +308,74 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
 
         {/* Focus Hours Chart */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%', flexShrink: 0 }}>
-          <h4 style={sectionHeaderStyle}>Focus Activity</h4>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '0 4px' }}>
+            <h4 style={sectionHeaderStyle}>Focus Activity</h4>
+            <div style={{
+              display: 'flex',
+              background: 'rgba(255, 255, 255, 0.05)',
+              padding: '2px',
+              borderRadius: '8px',
+              border: '1px solid rgba(255, 255, 255, 0.05)',
+            }}>
+              {([7, 30, 60] as const).map((days) => (
+                <button
+                  key={days}
+                  type="button"
+                  onClick={() => setActivityRange(days)}
+                  style={{
+                    padding: '4px 10px',
+                    borderRadius: '6px',
+                    border: 'none',
+                    fontSize: '9px',
+                    fontWeight: '700',
+                    cursor: 'pointer',
+                    background: activityRange === days ? 'rgba(255, 255, 255, 0.12)' : 'transparent',
+                    color: activityRange === days ? 'white' : 'rgba(255, 255, 255, 0.4)',
+                    transition: 'all 0.2s ease',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  {days}D
+                </button>
+              ))}
+            </div>
+          </div>
           <div style={{ 
             height: '160px', 
             width: '100%', 
             background: 'rgba(255,255,255,0.02)', 
             borderRadius: '20px', 
-            padding: '16px 12px 8px 12px', 
+            padding: '16px 8px 4px 4px', 
             border: '1px solid rgba(255,255,255,0.05)',
             boxSizing: 'border-box' 
           }}>
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={dailyData}>
-                <XAxis dataKey="date" hide />
-                <Tooltip 
+              <BarChart data={dailyData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+                <XAxis
+                  dataKey="dateLabel"
+                  axisLine={false}
+                  tickLine={false}
+                  interval={activityRange === 7 ? 0 : activityRange === 30 ? 4 : 9}
+                  tick={{ fill: 'rgba(255, 255, 255, 0.35)', fontSize: 9, fontFamily: theme.fonts.display }}
+                  dy={4}
+                />
+                <Tooltip
                   contentStyle={{ background: '#141414', border: '1px solid rgba(255, 255, 255, 0.1)', borderRadius: '12px', fontSize: '12px', fontFamily: theme.fonts.display }}
                   itemStyle={{ color: 'white' }}
+                  labelStyle={{ color: 'rgba(255, 255, 255, 0.6)', marginBottom: '4px' }}
                   cursor={{ fill: 'rgba(255, 255, 255, 0.05)' }}
-                  formatter={(value: any) => [formatDuration(Number(value) * 3600), 'Focus Time']}
+                  labelFormatter={(_, payload) => {
+                    const date = payload?.[0]?.payload?.date as string | undefined;
+                    return date ? formatActivityDate(date, 'tooltip') : '';
+                  }}
+                  formatter={(value) => [formatDuration(Number(value ?? 0) * 3600), 'Focus Time']}
                 />
-                <Bar 
-                  dataKey="hours" 
-                  fill={theme.colors.focus.primary} 
-                  radius={[4, 4, 0, 0]} 
-                  barSize={20}
+                <Bar
+                  dataKey="hours"
+                  fill={theme.colors.focus.primary}
+                  radius={[4, 4, 0, 0]}
+                  barSize={activityBarSize}
                 />
               </BarChart>
             </ResponsiveContainer>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the **Focus Activity** chart in Reports with readable dates and selectable time ranges.

## Changes

- **Formatted dates**: Chart axis and tooltip now show human-readable dates (e.g. "Mon, Jan 10" on the axis; full date in the tooltip) instead of raw `YYYY-MM-DD` strings.
- **Range toggle**: Added **7D**, **30D**, and **60D** buttons (matching the Project Mix toggle style) to switch how much history the bar chart shows.
- **Complete timelines**: Missing days in the selected range are filled with zero hours so the chart stays consistent.
- **Native data**: Extended the SQLite reports query from 7 to 60 days so 30D and 60D views have data on the Mac app.

## Testing

- `npm test` — all 64 tests pass
- `npx tsc --noEmit` — clean typecheck
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a92fea-9d86-4d6c-a89c-0d33e5b54cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a92fea-9d86-4d6c-a89c-0d33e5b54cce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

