### PR TITLE
Show more in task breakdown

### DIFF
--- a/src/test/ReportsView.test.tsx
+++ b/src/test/ReportsView.test.tsx
@@ -319,5 +319,75 @@ describe('ReportsView and Helpers', () => {
       const timeElements = screen.getAllByText('0m');
       expect(timeElements.length).toBeGreaterThan(0);
     });
+
+    it('should collapse Earlier tasks by default and expand on show more', () => {
+      const { hydrateReports } = useStatsStore.getState();
+      const earlierDate = new Date();
+      earlierDate.setDate(earlierDate.getDate() - 10);
+      const dateStr = earlierDate.toISOString().split('T')[0];
+
+      const taskBreakdown = Array.from({ length: 6 }, (_, i) => ({
+        title: `Older Task ${i + 1}`,
+        tag: 'Test Project',
+        duration: 1800,
+        estimatedPomos: 1,
+        avgSnapshotDuration: 1500,
+        date: dateStr,
+      }));
+
+      hydrateReports({
+        dailyStats: [],
+        projectDistribution: [],
+        totalFocusTime: 10800,
+        totalSessions: 6,
+        taskBreakdown,
+        streak: 1
+      });
+
+      render(<ReportsView onClose={() => {}} />);
+
+      expect(screen.getByText('Earlier')).toBeDefined();
+      expect(screen.getByText('Older Task 1')).toBeDefined();
+      expect(screen.getByText('Older Task 5')).toBeDefined();
+      expect(screen.queryByText('Older Task 6')).toBeNull();
+      expect(screen.getByText('Show 1 More Tasks')).toBeDefined();
+
+      fireEvent.click(screen.getByText('Show 1 More Tasks'));
+
+      expect(screen.getByText('Older Task 6')).toBeDefined();
+      expect(screen.getByText('Show Less')).toBeDefined();
+    });
+
+    it('should show all Earlier tasks when there are five or fewer', () => {
+      const { hydrateReports } = useStatsStore.getState();
+      const earlierDate = new Date();
+      earlierDate.setDate(earlierDate.getDate() - 10);
+      const dateStr = earlierDate.toISOString().split('T')[0];
+
+      const taskBreakdown = Array.from({ length: 3 }, (_, i) => ({
+        title: `Older Task ${i + 1}`,
+        tag: 'Test Project',
+        duration: 1800,
+        estimatedPomos: 1,
+        avgSnapshotDuration: 1500,
+        date: dateStr,
+      }));
+
+      hydrateReports({
+        dailyStats: [],
+        projectDistribution: [],
+        totalFocusTime: 5400,
+        totalSessions: 3,
+        taskBreakdown,
+        streak: 1
+      });
+
+      render(<ReportsView onClose={() => {}} />);
+
+      expect(screen.getByText('Older Task 1')).toBeDefined();
+      expect(screen.getByText('Older Task 2')).toBeDefined();
+      expect(screen.getByText('Older Task 3')).toBeDefined();
+      expect(screen.queryByText(/Show \d+ More Tasks/)).toBeNull();
+    });
   });
 });

--- a/src/ui/ReportsView.tsx
+++ b/src/ui/ReportsView.tsx
@@ -31,7 +31,9 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
   const stats = useStatsStore();
   const [exportStatus, setExportStatus] = useState<'idle' | 'exporting' | 'success'>('idle');
   const [isProjectExpanded, setIsProjectExpanded] = useState(false);
+  const [isEarlierTasksExpanded, setIsEarlierTasksExpanded] = useState(false);
   const [projectFilter, setProjectFilter] = useState<'all' | 'tagged'>('all');
+  const EARLIER_TASKS_PREVIEW_COUNT = 5;
   
   useEffect(() => {
     fetchReports();
@@ -509,8 +511,16 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
             </thead>
             <tbody>
               {taskData.length > 0 ? (
-                Object.entries(groupedTasks).map(([groupName, tasks]) => (
-                  tasks.length > 0 && (
+                Object.entries(groupedTasks).map(([groupName, tasks]) => {
+                  const isEarlierGroup = groupName === 'Earlier';
+                  const visibleTasks = isEarlierGroup && !isEarlierTasksExpanded
+                    ? tasks.slice(0, EARLIER_TASKS_PREVIEW_COUNT)
+                    : tasks;
+                  const hiddenEarlierCount = isEarlierGroup
+                    ? Math.max(tasks.length - EARLIER_TASKS_PREVIEW_COUNT, 0)
+                    : 0;
+
+                  return tasks.length > 0 && (
                     <React.Fragment key={groupName}>
                       <tr style={{ background: 'rgba(255,255,255,0.02)' }}>
                         <td colSpan={3} style={{ 
@@ -524,7 +534,7 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
                           {groupName}
                         </td>
                       </tr>
-                      {tasks.map((task, i) => {
+                      {visibleTasks.map((task, i) => {
                         const estimatedSeconds = task.estimatedPomos * task.avgSnapshotDuration;
                         const varianceSeconds = task.duration - estimatedSeconds;
                         
@@ -608,9 +618,48 @@ const ReportsView: React.FC<ReportsViewProps> = ({ onClose }) => {
                           </tr>
                         );
                       })}
+                      {isEarlierGroup && hiddenEarlierCount > 0 && (
+                        <tr>
+                          <td colSpan={3} style={{ padding: '4px 16px 12px' }}>
+                            <button
+                              onClick={() => setIsEarlierTasksExpanded(!isEarlierTasksExpanded)}
+                              style={{
+                                background: 'none',
+                                border: 'none',
+                                color: theme.colors.focus.primary,
+                                fontSize: '11px',
+                                fontWeight: '700',
+                                cursor: 'pointer',
+                                padding: '4px 0 0 0',
+                                textAlign: 'left',
+                                fontFamily: theme.fonts.brand,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '4px',
+                                opacity: 0.8,
+                                transition: 'opacity 0.2s ease'
+                              }}
+                              onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+                              onMouseLeave={(e) => e.currentTarget.style.opacity = '0.8'}
+                            >
+                              {isEarlierTasksExpanded ? (
+                                <>
+                                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
+                                  Show Less
+                                </>
+                              ) : (
+                                <>
+                                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                                  Show {hiddenEarlierCount} More Tasks
+                                </>
+                              )}
+                            </button>
+                          </td>
+                        </tr>
+                      )}
                     </React.Fragment>
-                  )
-                ))
+                  );
+                })
               ) : (
                   <tr>
                     <td colSpan={3} style={{ ...tdStyle, textAlign: 'center', color: theme.colors.text.muted, padding: '24px' }}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "Show more" collapsible for the **Earlier** subsection in Task Breakdown (tasks older than last week), matching the existing Project Mix expand/collapse pattern.

## Changes

- **Earlier tasks collapsed by default** — only the first 5 tasks are shown initially
- **Show more / Show less toggle** — expands to reveal all Earlier tasks, with a count in the button label (e.g. "Show 3 More Tasks")
- **Other date groups unchanged** — Today, Yesterday, and Last Week still show all tasks

## Implementation

- Reuses the same UX pattern as Project Mix (`isProjectExpanded` → `isEarlierTasksExpanded`)
- Preview limit: 5 tasks (consistent with Project Mix)
- Button styling and chevron icons match the existing show-more control

## Testing

- Added tests for collapsed/expanded Earlier tasks (6 tasks → 5 visible + show more)
- Added test confirming no show-more button when ≤5 Earlier tasks
- All 16 ReportsView tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e28aeef-558f-495b-9971-26f73452f906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e28aeef-558f-495b-9971-26f73452f906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

